### PR TITLE
Complete Wave 4: Companion resources and landing page generators

### DIFF
--- a/podcast/tools/generate_companion_resources.py
+++ b/podcast/tools/generate_companion_resources.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""
+Generate companion resources for podcast episodes (Wave 4, Task C3.1).
+
+Creates actionable companion materials from episode content:
+- One-page summary/cheat sheet (Markdown)
+- Action checklist (Markdown)
+- Framework extraction (Markdown for manual diagram creation)
+
+Usage:
+    python generate_companion_resources.py ../episodes/2025-12-26-topic-slug/
+    python generate_companion_resources.py ../episodes/2025-12-26-topic-slug/ --summary-only
+    python generate_companion_resources.py ../episodes/2025-12-26-topic-slug/ --dry-run
+
+Prerequisites:
+    - report.md exists in episode directory
+    - Optionally: content_plan.md for additional structure
+    - ANTHROPIC_API_KEY in environment for AI summarization (optional)
+
+The script will:
+    1. Read report.md and extract key content
+    2. Generate one-page summary with key points
+    3. Extract actionable items into checklist
+    4. Identify frameworks for diagram creation
+    5. Save outputs to companion/ subdirectory
+"""
+
+import argparse
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def extract_key_sections(content: str) -> dict:
+    """Extract key sections from report.md."""
+    sections = {}
+
+    # Find all ## headings and their content
+    heading_pattern = r'^## (.+?)$'
+    headings = list(re.finditer(heading_pattern, content, re.MULTILINE))
+
+    for i, match in enumerate(headings):
+        heading = match.group(1).strip()
+        start = match.end()
+        end = headings[i + 1].start() if i + 1 < len(headings) else len(content)
+        section_content = content[start:end].strip()
+        sections[heading] = section_content
+
+    return sections
+
+
+def extract_takeaways(content: str) -> list:
+    """Extract explicit takeaways from content."""
+    takeaways = []
+
+    # Look for numbered lists, key points, takeaways sections
+    patterns = [
+        r'(?:Key )?[Tt]akeaway[s]?:?\s*\n((?:[-*\d.]+\s+.+\n?)+)',
+        r'(?:Key )?[Pp]oint[s]?:?\s*\n((?:[-*\d.]+\s+.+\n?)+)',
+        r'(?:In summary|To summarize)[,:]?\s*\n((?:[-*\d.]+\s+.+\n?)+)',
+    ]
+
+    for pattern in patterns:
+        matches = re.findall(pattern, content, re.MULTILINE)
+        for match in matches:
+            items = re.findall(r'[-*\d.]+\s+(.+)', match)
+            takeaways.extend(items)
+
+    return takeaways[:10]  # Limit to top 10
+
+
+def extract_action_items(content: str) -> list:
+    """Extract actionable items from content."""
+    actions = []
+
+    # Look for actionable language
+    action_patterns = [
+        r'(?:should|must|need to|can|try to|consider|recommend)\s+(.+?)[.!]',
+        r'(?:Step \d+|First|Second|Third|Finally)[:\s]+(.+?)[.!]',
+        r'(?:Protocol|Framework|Process):\s*(.+?)[.!]',
+    ]
+
+    for pattern in action_patterns:
+        matches = re.findall(pattern, content, re.IGNORECASE)
+        actions.extend(matches)
+
+    # Deduplicate and clean
+    seen = set()
+    clean_actions = []
+    for action in actions:
+        action = action.strip()
+        if action and len(action) > 10 and action.lower() not in seen:
+            seen.add(action.lower())
+            clean_actions.append(action)
+
+    return clean_actions[:15]  # Limit to 15 items
+
+
+def extract_frameworks(content: str) -> list:
+    """Extract named frameworks and models from content."""
+    frameworks = []
+
+    # Look for framework indicators
+    patterns = [
+        r'(?:the )?([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*)\s+(?:framework|model|method|approach|protocol|system)',
+        r'(?:framework|model|method|approach|protocol|system)\s+(?:called|named|known as)\s+["\']?([^"\',.]+)',
+    ]
+
+    for pattern in patterns:
+        matches = re.findall(pattern, content, re.IGNORECASE)
+        frameworks.extend(matches)
+
+    # Deduplicate
+    seen = set()
+    clean_frameworks = []
+    for fw in frameworks:
+        fw = fw.strip()
+        if fw and len(fw) > 2 and fw.lower() not in seen:
+            seen.add(fw.lower())
+            clean_frameworks.append(fw)
+
+    return clean_frameworks[:5]  # Limit to 5
+
+
+def extract_statistics(content: str) -> list:
+    """Extract key statistics and numbers from content."""
+    stats = []
+
+    # Look for statistics with context
+    patterns = [
+        r'(\d+(?:\.\d+)?%[^.]*\.)',
+        r'(\$[\d,]+(?:\.\d+)?[^.]*\.)',
+        r'(\d+(?:\.\d+)?x[^.]*\.)',
+        r'(studies? (?:show|found|reveal)[^.]*\.)',
+    ]
+
+    for pattern in patterns:
+        matches = re.findall(pattern, content, re.IGNORECASE)
+        stats.extend(matches)
+
+    return stats[:10]  # Limit to 10
+
+
+def generate_summary(episode_title: str, sections: dict, takeaways: list,
+                     stats: list, frameworks: list) -> str:
+    """Generate one-page summary markdown."""
+    lines = []
+
+    lines.append(f"# {episode_title}: One-Page Summary")
+    lines.append("")
+    lines.append(f"*Generated: {datetime.now().strftime('%Y-%m-%d')}*")
+    lines.append("")
+
+    # Core Message
+    lines.append("## Core Message")
+    lines.append("")
+    if 'Introduction' in sections:
+        intro = sections['Introduction'][:500]
+        lines.append(intro.split('\n\n')[0])
+    elif 'Overview' in sections:
+        overview = sections['Overview'][:500]
+        lines.append(overview.split('\n\n')[0])
+    else:
+        lines.append("[Add 1-2 sentence summary of the episode's main thesis]")
+    lines.append("")
+
+    # Key Takeaways
+    lines.append("## Key Takeaways")
+    lines.append("")
+    if takeaways:
+        for i, takeaway in enumerate(takeaways[:5], 1):
+            lines.append(f"{i}. {takeaway}")
+    else:
+        lines.append("1. [Key takeaway 1]")
+        lines.append("2. [Key takeaway 2]")
+        lines.append("3. [Key takeaway 3]")
+    lines.append("")
+
+    # Key Statistics
+    if stats:
+        lines.append("## Key Statistics")
+        lines.append("")
+        for stat in stats[:5]:
+            stat = stat.strip()
+            if stat:
+                lines.append(f"- {stat}")
+        lines.append("")
+
+    # Frameworks
+    if frameworks:
+        lines.append("## Frameworks & Models")
+        lines.append("")
+        for fw in frameworks:
+            lines.append(f"- **{fw}**: [Brief description]")
+        lines.append("")
+
+    # Quick Reference
+    lines.append("## Quick Reference")
+    lines.append("")
+    lines.append("| Concept | Definition |")
+    lines.append("|---------|------------|")
+    lines.append("| [Term 1] | [Definition] |")
+    lines.append("| [Term 2] | [Definition] |")
+    lines.append("| [Term 3] | [Definition] |")
+    lines.append("")
+
+    # Action Items
+    lines.append("## Immediate Actions")
+    lines.append("")
+    lines.append("1. **Today**: [First action to take]")
+    lines.append("2. **This Week**: [Second action to take]")
+    lines.append("3. **This Month**: [Third action to take]")
+    lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append("*For full research and citations, see the complete report.*")
+
+    return "\n".join(lines)
+
+
+def generate_checklist(episode_title: str, actions: list, takeaways: list) -> str:
+    """Generate action checklist markdown."""
+    lines = []
+
+    lines.append(f"# {episode_title}: Action Checklist")
+    lines.append("")
+    lines.append(f"*Generated: {datetime.now().strftime('%Y-%m-%d')}*")
+    lines.append("")
+
+    lines.append("## Implementation Checklist")
+    lines.append("")
+
+    if actions:
+        for action in actions[:10]:
+            lines.append(f"- [ ] {action}")
+    else:
+        lines.append("- [ ] [Action item 1]")
+        lines.append("- [ ] [Action item 2]")
+        lines.append("- [ ] [Action item 3]")
+    lines.append("")
+
+    lines.append("## Key Points to Remember")
+    lines.append("")
+    if takeaways:
+        for takeaway in takeaways[:5]:
+            lines.append(f"- [ ] Understood: {takeaway}")
+    else:
+        lines.append("- [ ] Understood: [Key point 1]")
+        lines.append("- [ ] Understood: [Key point 2]")
+    lines.append("")
+
+    lines.append("## Progress Tracking")
+    lines.append("")
+    lines.append("| Date | Action Taken | Result |")
+    lines.append("|------|--------------|--------|")
+    lines.append("| | | |")
+    lines.append("| | | |")
+    lines.append("| | | |")
+    lines.append("")
+
+    lines.append("## Notes")
+    lines.append("")
+    lines.append("[Your notes here]")
+
+    return "\n".join(lines)
+
+
+def generate_framework_doc(episode_title: str, frameworks: list, content: str) -> str:
+    """Generate framework documentation for diagram creation."""
+    lines = []
+
+    lines.append(f"# {episode_title}: Frameworks for Visualization")
+    lines.append("")
+    lines.append(f"*Generated: {datetime.now().strftime('%Y-%m-%d')}*")
+    lines.append("")
+    lines.append("Use this document to create visual diagrams of key frameworks.")
+    lines.append("")
+
+    if frameworks:
+        for fw in frameworks:
+            lines.append(f"## {fw}")
+            lines.append("")
+
+            # Try to find context about this framework in the content
+            pattern = rf'{re.escape(fw)}[^.]*\.[^.]*\.'
+            matches = re.findall(pattern, content, re.IGNORECASE)
+            if matches:
+                lines.append(matches[0])
+            else:
+                lines.append("[Description of framework]")
+            lines.append("")
+
+            lines.append("### Components")
+            lines.append("")
+            lines.append("1. [Component 1]")
+            lines.append("2. [Component 2]")
+            lines.append("3. [Component 3]")
+            lines.append("")
+
+            lines.append("### Diagram Notes")
+            lines.append("")
+            lines.append("- Type: [Flowchart / Matrix / Cycle / Hierarchy]")
+            lines.append("- Key relationships: [How components connect]")
+            lines.append("- Visual emphasis: [What to highlight]")
+            lines.append("")
+    else:
+        lines.append("## [Framework Name]")
+        lines.append("")
+        lines.append("[No frameworks automatically detected. Add manually.]")
+        lines.append("")
+        lines.append("### Components")
+        lines.append("")
+        lines.append("1. [Component 1]")
+        lines.append("2. [Component 2]")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate companion resources for podcast episodes",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        "episode_dir",
+        help="Path to episode directory containing report.md"
+    )
+    parser.add_argument(
+        "--summary-only",
+        action="store_true",
+        help="Generate only the one-page summary"
+    )
+    parser.add_argument(
+        "--dry-run", "-n",
+        action="store_true",
+        help="Preview without writing files"
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="companion",
+        help="Output subdirectory name (default: companion)"
+    )
+
+    args = parser.parse_args()
+
+    # Resolve paths
+    episode_dir = Path(args.episode_dir).resolve()
+
+    if not episode_dir.exists():
+        print(f"Error: Episode directory not found: {episode_dir}", file=sys.stderr)
+        return 1
+
+    # Find report.md
+    report_path = episode_dir / "report.md"
+    if not report_path.exists():
+        print(f"Error: report.md not found in {episode_dir}", file=sys.stderr)
+        return 1
+
+    # Read content
+    content = report_path.read_text()
+
+    # Extract episode title from first heading
+    title_match = re.search(r'^# (.+)$', content, re.MULTILINE)
+    episode_title = title_match.group(1) if title_match else episode_dir.name
+
+    print(f"Episode: {episode_title}")
+    print(f"Source: {report_path}")
+
+    # Extract content
+    sections = extract_key_sections(content)
+    takeaways = extract_takeaways(content)
+    actions = extract_action_items(content)
+    frameworks = extract_frameworks(content)
+    stats = extract_statistics(content)
+
+    print(f"Found: {len(sections)} sections, {len(takeaways)} takeaways, {len(actions)} actions, {len(frameworks)} frameworks")
+
+    # Generate resources
+    summary = generate_summary(episode_title, sections, takeaways, stats, frameworks)
+
+    if args.dry_run:
+        print("\n=== ONE-PAGE SUMMARY ===\n")
+        print(summary)
+        if not args.summary_only:
+            checklist = generate_checklist(episode_title, actions, takeaways)
+            framework_doc = generate_framework_doc(episode_title, frameworks, content)
+            print("\n=== ACTION CHECKLIST ===\n")
+            print(checklist)
+            print("\n=== FRAMEWORK DOC ===\n")
+            print(framework_doc)
+        print("\n=== DRY RUN: No files written ===")
+        return 0
+
+    # Create output directory
+    output_dir = episode_dir / args.output_dir
+    output_dir.mkdir(exist_ok=True)
+
+    # Get slug from directory name
+    slug = episode_dir.name
+
+    # Write summary
+    summary_path = output_dir / f"{slug}-summary.md"
+    summary_path.write_text(summary)
+    print(f"Created: {summary_path}")
+
+    if not args.summary_only:
+        # Write checklist
+        checklist = generate_checklist(episode_title, actions, takeaways)
+        checklist_path = output_dir / f"{slug}-checklist.md"
+        checklist_path.write_text(checklist)
+        print(f"Created: {checklist_path}")
+
+        # Write framework doc
+        framework_doc = generate_framework_doc(episode_title, frameworks, content)
+        framework_path = output_dir / f"{slug}-frameworks.md"
+        framework_path.write_text(framework_doc)
+        print(f"Created: {framework_path}")
+
+    print(f"\nCompanion resources created in: {output_dir}")
+    print("Review and refine the generated content before publishing.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/podcast/tools/generate_landing_page.py
+++ b/podcast/tools/generate_landing_page.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""
+Generate episode landing page (Wave 4, Task C3.2).
+
+Creates an HTML landing page for each episode containing:
+- Episode overview and description
+- Key timestamps with links
+- Resources and tools mentioned
+- Companion resource downloads
+- Full transcript access
+- Report link
+
+Usage:
+    python generate_landing_page.py ../episodes/2025-12-26-topic-slug/
+    python generate_landing_page.py ../episodes/2025-12-26-topic-slug/ --dry-run
+
+Prerequisites:
+    - logs/metadata.md exists with required fields
+    - report.md exists
+    - Optional: companion/ directory with resources
+    - Optional: *_transcript.json for transcript
+
+The script will:
+    1. Parse logs/metadata.md for episode metadata
+    2. Read report.md for extended content
+    3. Check for companion resources
+    4. Generate responsive HTML landing page
+    5. Save as index.html in episode directory
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+
+def parse_metadata_md(metadata_path: Path) -> dict:
+    """Parse logs/metadata.md into a dictionary."""
+    content = metadata_path.read_text()
+    metadata = {}
+
+    # Extract title
+    title_match = re.search(r'^## Title\s*\n+(.+?)(?=\n#|\n\n#|\Z)', content, re.MULTILINE | re.DOTALL)
+    if title_match:
+        metadata['title'] = title_match.group(1).strip()
+
+    # Extract publication date
+    pub_match = re.search(r'^## Publication Date\s*\n+(.+?)(?=\n#|\n\n#|\Z)', content, re.MULTILINE | re.DOTALL)
+    if pub_match:
+        metadata['pub_date'] = pub_match.group(1).strip()
+
+    # Extract series info
+    series_match = re.search(r'\*\*Series Name:\*\*\s*(.+)', content)
+    if series_match:
+        series_name = series_match.group(1).strip()
+        if series_name and series_name.lower() not in ['none', 'n/a', '']:
+            metadata['series_name'] = series_name
+
+    # Extract audio info
+    duration_match = re.search(r'\*\*Duration:\*\*\s*(\S+)', content)
+    if duration_match:
+        metadata['duration'] = duration_match.group(1).strip()
+
+    # Extract description
+    desc_match = re.search(r'^## Description \(Plain Text[^)]*\)\s*\n+(.+?)(?=\n#|\Z)', content, re.MULTILINE | re.DOTALL)
+    if desc_match:
+        metadata['description'] = desc_match.group(1).strip()
+
+    # Extract What You'll Learn
+    learn_match = re.search(r'^## What You\'ll Learn.*?\n((?:[-*]\s+.+\n?)+)', content, re.MULTILINE)
+    if learn_match:
+        items = re.findall(r'[-*]\s+(.+)', learn_match.group(1))
+        metadata['what_youll_learn'] = items
+
+    # Extract Key Timestamps
+    timestamps_match = re.search(r'^## Key Timestamps.*?\n((?:[-*]\s+.+\n?)+)', content, re.MULTILINE)
+    if timestamps_match:
+        timestamps = []
+        for line in timestamps_match.group(1).split('\n'):
+            match = re.match(r'[-*]\s+\*?\*?\[?(\d+:\d+(?::\d+)?)\]?\*?\*?\s*[-–]\s*(.+)', line)
+            if match:
+                timestamps.append({'time': match.group(1), 'label': match.group(2).strip()})
+        metadata['timestamps'] = timestamps
+
+    # Extract Resources
+    resources_match = re.search(r'^## Resources.*?\n(.+?)(?=\n## |\Z)', content, re.MULTILINE | re.DOTALL)
+    if resources_match:
+        resources = []
+        for line in resources_match.group(1).split('\n'):
+            # Look for markdown links
+            link_match = re.search(r'\[(.+?)\]\((.+?)\)', line)
+            if link_match:
+                resources.append({'name': link_match.group(1), 'url': link_match.group(2)})
+        metadata['resources'] = resources
+
+    # Extract keywords
+    keywords_match = re.search(r'^## Keywords\s*\n+(.+?)(?=\n#|\Z)', content, re.MULTILINE | re.DOTALL)
+    if keywords_match:
+        metadata['keywords'] = keywords_match.group(1).strip()
+
+    return metadata
+
+
+def get_companion_resources(episode_dir: Path) -> list:
+    """Find companion resources in the episode directory."""
+    resources = []
+    companion_dir = episode_dir / "companion"
+
+    if companion_dir.exists():
+        for file in companion_dir.iterdir():
+            if file.suffix in ['.md', '.pdf', '.png', '.jpg']:
+                resource_type = "Document"
+                if 'summary' in file.name.lower():
+                    resource_type = "One-Page Summary"
+                elif 'checklist' in file.name.lower():
+                    resource_type = "Action Checklist"
+                elif 'framework' in file.name.lower():
+                    resource_type = "Framework Guide"
+                elif file.suffix in ['.png', '.jpg']:
+                    resource_type = "Diagram"
+
+                resources.append({
+                    'name': resource_type,
+                    'file': file.name,
+                    'path': f"companion/{file.name}"
+                })
+
+    return resources
+
+
+def get_transcript_preview(episode_dir: Path, max_chars: int = 500) -> str:
+    """Get a preview of the transcript."""
+    transcript_files = list(episode_dir.glob("*_transcript.json"))
+    if not transcript_files:
+        return None
+
+    try:
+        with open(transcript_files[0]) as f:
+            data = json.load(f)
+            if 'text' in data:
+                text = data['text'][:max_chars]
+                return text + "..." if len(data['text']) > max_chars else text
+    except:
+        pass
+    return None
+
+
+def generate_html(metadata: dict, episode_dir: Path, companion_resources: list,
+                  transcript_preview: str) -> str:
+    """Generate the HTML landing page."""
+    title = escape(metadata.get('title', 'Episode'))
+    description = escape(metadata.get('description', ''))
+    duration = metadata.get('duration', '')
+    pub_date = metadata.get('pub_date', '')
+    series = metadata.get('series_name', '')
+
+    # Get episode slug for URLs
+    slug = episode_dir.name
+
+    # Build base URL
+    base_url = f"https://research.yuda.me/podcast/episodes/{slug}"
+
+    html = f'''<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{title} | Yudame Research Podcast</title>
+    <meta name="description" content="{description[:160]}">
+    <meta property="og:title" content="{title}">
+    <meta property="og:description" content="{description[:160]}">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="{base_url}/">
+    <style>
+        :root {{
+            --primary: #2c3e50;
+            --secondary: #3498db;
+            --background: #faf8f5;
+            --text: #333;
+            --border: #e0e0e0;
+        }}
+        * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+        body {{
+            font-family: 'Georgia', serif;
+            line-height: 1.7;
+            color: var(--text);
+            background: var(--background);
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }}
+        header {{
+            margin-bottom: 2rem;
+            padding-bottom: 1rem;
+            border-bottom: 2px solid var(--primary);
+        }}
+        h1 {{
+            font-size: 2rem;
+            color: var(--primary);
+            margin-bottom: 0.5rem;
+        }}
+        .meta {{
+            color: #666;
+            font-size: 0.9rem;
+        }}
+        .meta span {{ margin-right: 1rem; }}
+        section {{
+            margin: 2rem 0;
+            padding: 1.5rem;
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }}
+        h2 {{
+            font-size: 1.3rem;
+            color: var(--primary);
+            margin-bottom: 1rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border);
+        }}
+        ul {{ list-style: none; }}
+        li {{ margin: 0.5rem 0; padding-left: 1.5rem; position: relative; }}
+        li::before {{
+            content: "•";
+            color: var(--secondary);
+            position: absolute;
+            left: 0;
+        }}
+        a {{
+            color: var(--secondary);
+            text-decoration: none;
+        }}
+        a:hover {{ text-decoration: underline; }}
+        .timestamps li::before {{ content: ""; }}
+        .timestamps .time {{
+            font-family: monospace;
+            background: #f0f0f0;
+            padding: 0.2rem 0.5rem;
+            border-radius: 4px;
+            margin-right: 0.5rem;
+        }}
+        .cta {{
+            display: inline-block;
+            background: var(--secondary);
+            color: white;
+            padding: 0.75rem 1.5rem;
+            border-radius: 4px;
+            margin: 0.5rem 0.5rem 0.5rem 0;
+            transition: background 0.2s;
+        }}
+        .cta:hover {{
+            background: var(--primary);
+            text-decoration: none;
+        }}
+        .transcript-preview {{
+            background: #f9f9f9;
+            padding: 1rem;
+            border-left: 3px solid var(--secondary);
+            font-style: italic;
+            color: #555;
+        }}
+        footer {{
+            margin-top: 3rem;
+            padding-top: 1rem;
+            border-top: 1px solid var(--border);
+            text-align: center;
+            font-size: 0.85rem;
+            color: #666;
+        }}
+        @media (max-width: 600px) {{
+            h1 {{ font-size: 1.5rem; }}
+            section {{ padding: 1rem; }}
+        }}
+    </style>
+</head>
+<body>
+    <header>
+        <h1>{title}</h1>
+        <div class="meta">
+'''
+
+    if series:
+        html += f'            <span>Series: {escape(series)}</span>\n'
+    if duration:
+        html += f'            <span>Duration: {escape(duration)}</span>\n'
+    if pub_date:
+        html += f'            <span>Published: {escape(pub_date)}</span>\n'
+
+    html += '''        </div>
+    </header>
+
+    <section>
+        <h2>Overview</h2>
+'''
+    html += f'        <p>{description}</p>\n'
+    html += '''    </section>
+'''
+
+    # What You'll Learn
+    if metadata.get('what_youll_learn'):
+        html += '''
+    <section>
+        <h2>What You'll Learn</h2>
+        <ul>
+'''
+        for item in metadata['what_youll_learn']:
+            html += f'            <li>{escape(item)}</li>\n'
+        html += '''        </ul>
+    </section>
+'''
+
+    # Key Timestamps
+    if metadata.get('timestamps'):
+        html += '''
+    <section>
+        <h2>Key Timestamps</h2>
+        <ul class="timestamps">
+'''
+        for ts in metadata['timestamps']:
+            html += f'            <li><span class="time">{escape(ts["time"])}</span> {escape(ts["label"])}</li>\n'
+        html += '''        </ul>
+    </section>
+'''
+
+    # Resources
+    if metadata.get('resources'):
+        html += '''
+    <section>
+        <h2>Resources & Tools</h2>
+        <ul>
+'''
+        for resource in metadata['resources']:
+            html += f'            <li><a href="{escape(resource["url"])}" target="_blank">{escape(resource["name"])}</a></li>\n'
+        html += '''        </ul>
+    </section>
+'''
+
+    # Companion Resources
+    if companion_resources:
+        html += '''
+    <section>
+        <h2>Companion Downloads</h2>
+        <ul>
+'''
+        for resource in companion_resources:
+            html += f'            <li><a href="{escape(resource["path"])}">{escape(resource["name"])}</a></li>\n'
+        html += '''        </ul>
+    </section>
+'''
+
+    # Transcript Preview
+    if transcript_preview:
+        html += f'''
+    <section>
+        <h2>Transcript Preview</h2>
+        <div class="transcript-preview">
+            {escape(transcript_preview)}
+        </div>
+        <p style="margin-top: 1rem;"><a href="{slug}_transcript.json">View full transcript</a></p>
+    </section>
+'''
+
+    # CTAs
+    html += f'''
+    <section>
+        <h2>Access the Full Episode</h2>
+        <a href="{base_url}/{slug}.mp3" class="cta">Listen to Episode</a>
+        <a href="{base_url}/report.md" class="cta">Read Full Report</a>
+        <a href="{base_url}/sources.md" class="cta">View Sources</a>
+    </section>
+
+    <footer>
+        <p>Yudame Research Podcast &copy; {datetime.now().year}</p>
+        <p><a href="https://research.yuda.me/podcast/feed.xml">Subscribe via RSS</a></p>
+    </footer>
+</body>
+</html>
+'''
+
+    return html
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate episode landing page",
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        "episode_dir",
+        help="Path to episode directory containing logs/metadata.md"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default="index.html",
+        help="Output filename (default: index.html)"
+    )
+    parser.add_argument(
+        "--dry-run", "-n",
+        action="store_true",
+        help="Preview without writing files"
+    )
+
+    args = parser.parse_args()
+
+    # Resolve paths
+    episode_dir = Path(args.episode_dir).resolve()
+
+    if not episode_dir.exists():
+        print(f"Error: Episode directory not found: {episode_dir}", file=sys.stderr)
+        return 1
+
+    # Find metadata.md
+    metadata_path = episode_dir / "logs" / "metadata.md"
+    if not metadata_path.exists():
+        print(f"Error: logs/metadata.md not found in {episode_dir}", file=sys.stderr)
+        return 1
+
+    print(f"Episode: {episode_dir.name}")
+    print(f"Metadata: {metadata_path}")
+
+    # Parse metadata
+    metadata = parse_metadata_md(metadata_path)
+
+    if 'title' not in metadata:
+        print("Error: Could not find title in metadata.md", file=sys.stderr)
+        return 1
+
+    print(f"Title: {metadata['title']}")
+
+    # Get companion resources
+    companion_resources = get_companion_resources(episode_dir)
+    print(f"Companion resources: {len(companion_resources)}")
+
+    # Get transcript preview
+    transcript_preview = get_transcript_preview(episode_dir)
+    if transcript_preview:
+        print("Transcript: Found")
+
+    # Generate HTML
+    html = generate_html(metadata, episode_dir, companion_resources, transcript_preview)
+
+    if args.dry_run:
+        print("\n=== GENERATED HTML ===\n")
+        print(html[:2000] + "...\n[truncated]" if len(html) > 2000 else html)
+        print("\n=== DRY RUN: No files written ===")
+        return 0
+
+    # Write output
+    output_path = episode_dir / args.output
+    output_path.write_text(html)
+    print(f"\nCreated: {output_path}")
+    print(f"URL: https://research.yuda.me/podcast/episodes/{episode_dir.name}/")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Completes all remaining Wave 4 tasks from the podcast episode improvements plan, closing issue #10.

### New Scripts

**`generate_companion_resources.py`** (C3.1)
- Extracts key content from `report.md`
- Generates one-page summary with takeaways and statistics
- Creates action checklist from actionable items
- Produces framework documentation for diagram creation
- Outputs to `companion/` subdirectory

**`generate_landing_page.py`** (C3.2)
- Parses `logs/metadata.md` for episode metadata
- Generates responsive HTML landing page
- Includes: overview, timestamps, resources, companion downloads
- Adds transcript preview if available
- Mobile-friendly design with clean typography

### Usage

```bash
# Generate companion resources
python podcast/tools/generate_companion_resources.py podcast/episodes/2025-01-15-topic/

# Generate landing page
python podcast/tools/generate_landing_page.py podcast/episodes/2025-01-15-topic/

# Preview without writing (both scripts)
python podcast/tools/generate_companion_resources.py podcast/episodes/2025-01-15-topic/ --dry-run
```

### Wave 4 Status: Complete

| Task | Status |
|------|--------|
| C1.1-C1.3 | ✅ Previously completed (metadata template, update_feed.py) |
| C2.1-C2.3 | ✅ Previously completed (feed.xml enhancements) |
| C3.1 | ✅ This PR (companion resources) |
| C3.2 | ✅ This PR (landing page) |

### Related Issues

- Closes #10 (Episode Planning Framework - Wave 4 complete)
- Wave 6 experiments moved to #11

## Test plan

- [ ] Run `generate_companion_resources.py --dry-run` on existing episode
- [ ] Run `generate_landing_page.py --dry-run` on existing episode
- [ ] Verify generated markdown structure is sensible
- [ ] Verify generated HTML renders correctly